### PR TITLE
Add more logging information for dropped packets by netpol

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -95,6 +95,7 @@ type networkPolicyInfo struct {
 	name        string
 	namespace   string
 	podSelector labels.Selector
+	annotations map[string]string
 
 	// set of pods matching network policy spec podselector label selector
 	targetPods map[string]podInfo

--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -208,7 +208,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 					comment := "rule to ACCEPT traffic from source pods to dest pods selected by policy name " +
 						policy.name + " namespace " + policy.namespace
 					if err := npc.appendRuleToPolicyChain(policyChainName, comment, srcPodIPSetName, namedPortIPSetName,
-						endPoints.protocol, endPoints.port, endPoints.endport, ipFamily); err != nil {
+						endPoints.protocol, endPoints.port, endPoints.endport, ipFamily, policy); err != nil {
 						return err
 					}
 				}
@@ -221,7 +221,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 				comment := "rule to ACCEPT traffic from source pods to dest pods selected by policy name " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName,
-					comment, srcPodIPSetName, targetDestPodIPSetName, "", "", "", ipFamily); err != nil {
+					comment, srcPodIPSetName, targetDestPodIPSetName, "", "", "", ipFamily, policy); err != nil {
 					return err
 				}
 			}
@@ -234,7 +234,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 				comment := "rule to ACCEPT traffic from all sources to dest pods selected by policy name: " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, "", targetDestPodIPSetName,
-					portProtocol.protocol, portProtocol.port, portProtocol.endport, ipFamily); err != nil {
+					portProtocol.protocol, portProtocol.port, portProtocol.endport, ipFamily, policy); err != nil {
 					return err
 				}
 			}
@@ -252,7 +252,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 				comment := "rule to ACCEPT traffic from all sources to dest pods selected by policy name: " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName,
-					comment, "", namedPortIPSetName, endPoints.protocol, endPoints.port, endPoints.endport, ipFamily); err != nil {
+					comment, "", namedPortIPSetName, endPoints.protocol, endPoints.port, endPoints.endport, ipFamily, policy); err != nil {
 					return err
 				}
 			}
@@ -264,7 +264,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 			comment := "rule to ACCEPT traffic from all sources to dest pods selected by policy name: " +
 				policy.name + " namespace " + policy.namespace
 			if err := npc.appendRuleToPolicyChain(policyChainName, comment, "", targetDestPodIPSetName,
-				"", "", "", ipFamily); err != nil {
+				"", "", "", ipFamily, policy); err != nil {
 				return err
 			}
 		}
@@ -280,7 +280,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 						policy.name + " namespace " + policy.namespace
 					if err := npc.appendRuleToPolicyChain(policyChainName, comment, srcIPBlockIPSetName,
 						targetDestPodIPSetName, portProtocol.protocol, portProtocol.port,
-						portProtocol.endport, ipFamily); err != nil {
+						portProtocol.endport, ipFamily, policy); err != nil {
 						return err
 					}
 				}
@@ -297,7 +297,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 					comment := "rule to ACCEPT traffic from specified ipBlocks to dest pods selected by policy name: " +
 						policy.name + " namespace " + policy.namespace
 					if err := npc.appendRuleToPolicyChain(policyChainName, comment, srcIPBlockIPSetName, namedPortIPSetName,
-						endPoints.protocol, endPoints.port, endPoints.endport, ipFamily); err != nil {
+						endPoints.protocol, endPoints.port, endPoints.endport, ipFamily, policy); err != nil {
 						return err
 					}
 				}
@@ -306,7 +306,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 				comment := "rule to ACCEPT traffic from specified ipBlocks to dest pods selected by policy name: " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, srcIPBlockIPSetName,
-					targetDestPodIPSetName, "", "", "", ipFamily); err != nil {
+					targetDestPodIPSetName, "", "", "", ipFamily, policy); err != nil {
 					return err
 				}
 			}
@@ -363,7 +363,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 					comment := "rule to ACCEPT traffic from source pods to dest pods selected by policy name " +
 						policy.name + " namespace " + policy.namespace
 					if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
-						namedPortIPSetName, endPoints.protocol, endPoints.port, endPoints.endport, ipFamily); err != nil {
+						namedPortIPSetName, endPoints.protocol, endPoints.port, endPoints.endport, ipFamily, policy); err != nil {
 						return err
 					}
 				}
@@ -376,7 +376,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 				comment := "rule to ACCEPT traffic from source pods to dest pods selected by policy name " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
-					dstPodIPSetName, "", "", "", ipFamily); err != nil {
+					dstPodIPSetName, "", "", "", ipFamily, policy); err != nil {
 					return err
 				}
 			}
@@ -389,7 +389,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 				comment := "rule to ACCEPT traffic from source pods to all destinations selected by policy name: " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
-					"", portProtocol.protocol, portProtocol.port, portProtocol.endport, ipFamily); err != nil {
+					"", portProtocol.protocol, portProtocol.port, portProtocol.endport, ipFamily, policy); err != nil {
 					return err
 				}
 			}
@@ -397,7 +397,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 				comment := "rule to ACCEPT traffic from source pods to all destinations selected by policy name: " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
-					"", portProtocol.protocol, portProtocol.port, portProtocol.endport, ipFamily); err != nil {
+					"", portProtocol.protocol, portProtocol.port, portProtocol.endport, ipFamily, policy); err != nil {
 					return err
 				}
 			}
@@ -409,7 +409,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 			comment := "rule to ACCEPT traffic from source pods to all destinations selected by policy name: " +
 				policy.name + " namespace " + policy.namespace
 			if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
-				"", "", "", "", ipFamily); err != nil {
+				"", "", "", "", ipFamily, policy); err != nil {
 				return err
 			}
 		}
@@ -424,7 +424,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 						policy.name + " namespace " + policy.namespace
 					if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
 						dstIPBlockIPSetName, portProtocol.protocol, portProtocol.port,
-						portProtocol.endport, ipFamily); err != nil {
+						portProtocol.endport, ipFamily, policy); err != nil {
 						return err
 					}
 				}
@@ -433,7 +433,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 				comment := "rule to ACCEPT traffic from source pods to specified ipBlocks selected by policy name: " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
-					dstIPBlockIPSetName, "", "", "", ipFamily); err != nil {
+					dstIPBlockIPSetName, "", "", "", ipFamily, policy); err != nil {
 					return err
 				}
 			}
@@ -443,7 +443,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 }
 
 func (npc *NetworkPolicyController) appendRuleToPolicyChain(policyChainName, comment, srcIPSetName, dstIPSetName,
-	protocol, dPort, endDport string, ipFamily api.IPFamily) error {
+	protocol, dPort, endDport string, ipFamily api.IPFamily, policy networkPolicyInfo) error {
 
 	args := make([]string, 0)
 	args = append(args, "-A", policyChainName)
@@ -476,6 +476,21 @@ func (npc *NetworkPolicyController) appendRuleToPolicyChain(policyChainName, com
 	args = append(args, "-m", "mark", "--mark", "0x10000/0x10000", "-j", "RETURN", "\n")
 	npc.filterTableRules[ipFamily].WriteString(strings.Join(args, " "))
 
+	// Extra logs to get more information about the policy dropping the packet via ulog2
+	logRuleComment := "\"rule to log dropped traffic\""
+
+	// The network policy annotation can include a log config
+	limit, limitBurst := getIptablesNFlogLimit(policy.annotations)
+
+	// LogComment is capped at 64 characters and we are using 16, hence policyNamespace and policyName
+	// must fit in 48 characters otherwise we can only log the first 24 characters
+	policyNamespaceAndName := safeJoin(policy.namespace, policy.name)
+	logComment := "\"DROP by policy " + policyNamespaceAndName + "\""
+	logArgs := []string{"-A", policyChainName, "-m", "comment", "--comment", logRuleComment, "-m", "limit",
+		"--limit", limit, "--limit-burst", limitBurst, "-m", "mark", "!", "--mark", "0x10000/0x10000",
+		"-j", "NFLOG", "--nflog-group", "100", "--nflog-prefix", logComment, "\n"}
+	npc.filterTableRules[ipFamily].WriteString(strings.Join(logArgs, " "))
+
 	return nil
 }
 
@@ -495,6 +510,7 @@ func (npc *NetworkPolicyController) buildNetworkPoliciesInfo() ([]networkPolicyI
 			namespace:   policy.Namespace,
 			podSelector: podSelector,
 			policyType:  kubeIngressPolicyType,
+			annotations: policy.Annotations,
 		}
 
 		ingressType, egressType := false, false

--- a/pkg/controllers/netpol/utils.go
+++ b/pkg/controllers/netpol/utils.go
@@ -5,24 +5,30 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/cloudnativelabs/kube-router/pkg/utils"
 	api "k8s.io/api/core/v1"
 	klog "k8s.io/klog/v2"
 	utilsnet "k8s.io/utils/net"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
 	PodCompleted api.PodPhase = "Completed"
 )
 
+var (
+	stringSuffixes = sets.NewString("second", "minute", "hour", "day", "s", "m", "h", "d")
+)
+
 // isPodUpdateNetPolRelevant checks the attributes that we care about for building NetworkPolicies on the host and if it
 // finds a relevant change, it returns true otherwise it returns false. The things we care about for NetworkPolicies:
-// 1) Is the phase of the pod changing? (matters for catching completed, succeeded, or failed jobs)
-// 2) Is the pod IP changing? (changes how the network policy is applied to the host)
-// 3) Is the pod's host IP changing? (should be caught in the above, with the CNI kube-router runs with but we check
+//  1. Is the phase of the pod changing? (matters for catching completed, succeeded, or failed jobs)
+//  2. Is the pod IP changing? (changes how the network policy is applied to the host)
+//  3. Is the pod's host IP changing? (should be caught in the above, with the CNI kube-router runs with but we check
 //     this as well for sanity)
-// 4) Is a pod's label changing? (potentially changes which NetworkPolicies select this pod)
+//  4. Is a pod's label changing? (potentially changes which NetworkPolicies select this pod)
 func isPodUpdateNetPolRelevant(oldPod, newPod *api.Pod) bool {
 	return newPod.Status.Phase != oldPod.Status.Phase ||
 		newPod.Status.PodIP != oldPod.Status.PodIP ||
@@ -118,7 +124,7 @@ func (npc *NetworkPolicyController) createPodWithPortPolicyRule(ports []protocol
 		comment := "rule to ACCEPT traffic from source pods to dest pods selected by policy name " +
 			policy.name + " namespace " + policy.namespace
 		if err := npc.appendRuleToPolicyChain(policyName, comment, srcSetName, dstSetName, portProtocol.protocol,
-			portProtocol.port, portProtocol.endport, ipFamily); err != nil {
+			portProtocol.port, portProtocol.endport, ipFamily, policy); err != nil {
 			return err
 		}
 	}
@@ -142,3 +148,83 @@ func getPodIPv4Address(pod podInfo) (string, error) {
 	}
 	return "", fmt.Errorf("pod %s has no IPv4Address", pod.name)
 }
+
+// safeJoin joins the namespace and name, ensuring that the result is less than or equal to 48 characters
+func safeJoin(namespace string, name string) string {
+	if (len(namespace) + len(name)) < 48 {
+		return namespace + "/" + name
+	}
+
+	// We must create at least one substring
+	if len(namespace) < 24 {
+		lengthSubString := (48 - len(namespace) - 1)
+		return namespace + "/" + name[0:lengthSubString]
+	}
+
+	if len(name) < 24 {
+		lengthSubString := (48 - len(name) - 1)
+		return namespace[0:lengthSubString] + "/" + name
+	}
+
+	//If we arrive here, both are over 24 characters
+	return namespace[0:23] + "/" + name[0:23]
+}
+
+// getIptablesNFlogLimit reads the annotations setting the nflog limit and limit-burst config
+// "kube-router.io/netpol-nflog-limit" and "kube-router.io/netpol-nflog-limit-burst"
+func getIptablesNFlogLimit(annotations map[string]string) (string, string) {
+	defaultLimit := "10/minute"
+	defaultLimitBurst := "10"
+
+	limit, ok := annotations["kube-router.io/netpol-nflog-limit"]
+	if !ok {
+		limit = defaultLimit
+	}
+
+	limitBurst, ok := annotations["kube-router.io/netpol-nflog-limit-burst"]
+	if !ok {
+		limitBurst = defaultLimitBurst
+	}
+
+	if !areNFlogParamsCorrect(limit, limitBurst) {
+		klog.Warning("Network Policy annotations are wrong, default values will be used. Check the docs for more information")
+		return defaultLimit, defaultLimitBurst
+	}
+
+	return limit, limitBurst
+}
+
+
+// areNFlogParamsCorrect verifies that the nflog parameters are correct
+// * kube-router.io/netpol-nflog-limit must be an integer, with an optional "/second", "/minute", "/hour", "/day" or the first character of each time unit
+// * kube-router.io/netpol-nflog-limit-burst must be an integer
+func areNFlogParamsCorrect(limit string, limitBurst string) bool {
+
+	// If limit does not set a time unit, check if limit and limitBurst are integers 
+	param := strings.Split(limit, "/")
+	if len(param) == 1 {
+		if isInteger(param[0]) && isInteger(limitBurst) {
+			return true
+		}
+	}
+	
+	// If limit sets a time unit, check if it is among the supported ones
+	if len(param) == 2 {
+		if stringSuffixes.Has(param[1]) {
+			// If the time unit is supported, check that limit and limitBurst are integers
+			if isInteger(param[0]) && isInteger(limitBurst) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// isInteger returns true if the passed value is an integer
+func isInteger(x string) bool {
+	if _, err := strconv.Atoi(x); err == nil {
+		return true
+	}
+	return false
+} 


### PR DESCRIPTION
This PR adds one extra commit to our fork of kube-router to increase logging: It adds one extra logging rule per network policy so that we can see what network policy is dropping the packets.

That extra line includes the iptables flags `limit` and `limit-burst` which reduces the logging messages. Those values are configurable by setting the annotations:
* kube-router.io/netpol-nflog-limit
* kube-router.io.io/netpol-nflog-limit-burst
in the network policy manifest

The new information looks like this:
```
Oct 20 12:40:30 mbuil-vm0 DROP by policy default/test-network-policy IN=cni0 OUT=cni0 MAC=06:d6:12:fc:d7:22:ca:5e:1d:37:c8:74:08:00 SRC=10.42.0.10 DST=10.42.0.9 LEN=60 TOS=00 PREC=0x00 TTL=64 ID=30453 DF PROTO=TCP SPT=51648 DPT=80 SEQ=1265687747 ACK=0 WINDOW=64860 SYN URGP=0 MARK=0 
Oct 20 12:40:30 mbuil-vm0  IN=cni0 OUT=cni0 MAC=06:d6:12:fc:d7:22:ca:5e:1d:37:c8:74:08:00 SRC=10.42.0.10 DST=10.42.0.9 LEN=60 TOS=00 PREC=0x00 TTL=64 ID=30453 DF PROTO=TCP SPT=51648 DPT=80 SEQ=1265687747 ACK=0 WINDOW=64860 SYN URGP=0 MARK=0
```

Since we can only add 64 characters to the log, we are pruning the name of the policy and the namespace if they are longer than 24 characters

Signed-off-by: Manuel Buil <mbuil@suse.com>