### PR TITLE
Change default rules to RETURN

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -503,7 +503,7 @@ func (npc *NetworkPolicyController) ensureExplicitAccept() {
 		for _, chain := range defaultChains {
 			comment := "\"rule to explicitly ACCEPT traffic that comply to network policies\""
 			args := []string{"-m", "comment", "--comment", comment, "-m", "mark", "--mark", "0x20000/0x20000",
-				"-j", "ACCEPT"}
+				"-j", "RETURN"}
 			utils.AppendUnique(filterTableRules, chain, args)
 		}
 	}


### PR DESCRIPTION
Change the default rules to RETURN to left the packet to flow to the kube-proxy rules https://github.com/k3s-io/k3s/issues/6691