### PR TITLE
Fix IP list when multiple replica and port name is used

### DIFF
--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -859,7 +859,8 @@ func (npc *NetworkPolicyController) grabNamedPortFromPod(pod *api.Pod, namedPort
 					protocolAndPort: protocolAndPort{port: containerPort, protocol: protocol},
 				}
 			} else {
-				eps.ips = ips
+				eps.ips[api.IPv4Protocol] = append(eps.ips[api.IPv4Protocol], ips[api.IPv4Protocol]...)
+				eps.ips[api.IPv6Protocol] = append(eps.ips[api.IPv6Protocol], ips[api.IPv6Protocol]...)
 			}
 		}
 	}


### PR DESCRIPTION
This PR will fix an issue when a port name is used on the network policy and there are multiple replicas of the target service.
https://github.com/k3s-io/k3s/issues/7446
https://github.com/k3s-io/k3s/issues/7391