### PR TITLE
Fix multiple NFLOG on a single policy chain

### DIFF
--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -142,6 +142,20 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains(networkPoliciesInfo 
 				}
 				activePolicyIPSets[targetSourcePodIPSetName] = true
 			}
+			// Extra logs to get more information about the policy dropping the packet via ulog2
+			logRuleComment := "\"rule to log dropped traffic\""
+
+			// The network policy annotation can include a log config
+			limit, limitBurst := getIptablesNFlogLimit(policy.annotations)
+
+			// LogComment is capped at 64 characters and we are using 16, hence policyNamespace and policyName
+			// must fit in 48 characters otherwise we can only log the first 24 characters
+			policyNamespaceAndName := safeJoin(policy.namespace, policy.name)
+			logComment := "\"DROP by policy " + policyNamespaceAndName + "\""
+			logArgs := []string{"-A", policyChainName, "-m", "comment", "--comment", logRuleComment, "-m", "limit",
+				"--limit", limit, "--limit-burst", limitBurst, "-m", "mark", "!", "--mark", "0x10000/0x10000",
+				"-j", "NFLOG", "--nflog-group", "100", "--nflog-prefix", logComment, "\n"}
+			npc.filterTableRules[ipFamily].WriteString(strings.Join(logArgs, " "))
 		}
 	}
 
@@ -225,7 +239,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 					comment := "rule to ACCEPT traffic from source pods to dest pods selected by policy name " +
 						policy.name + " namespace " + policy.namespace
 					if err := npc.appendRuleToPolicyChain(policyChainName, comment, srcPodIPSetName, namedPortIPSetName,
-						endPoints.protocol, endPoints.port, endPoints.endport, ipFamily, policy); err != nil {
+						endPoints.protocol, endPoints.port, endPoints.endport, ipFamily); err != nil {
 						return err
 					}
 				}
@@ -238,7 +252,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 				comment := "rule to ACCEPT traffic from source pods to dest pods selected by policy name " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName,
-					comment, srcPodIPSetName, targetDestPodIPSetName, "", "", "", ipFamily, policy); err != nil {
+					comment, srcPodIPSetName, targetDestPodIPSetName, "", "", "", ipFamily); err != nil {
 					return err
 				}
 			}
@@ -251,7 +265,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 				comment := "rule to ACCEPT traffic from all sources to dest pods selected by policy name: " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, "", targetDestPodIPSetName,
-					portProtocol.protocol, portProtocol.port, portProtocol.endport, ipFamily, policy); err != nil {
+					portProtocol.protocol, portProtocol.port, portProtocol.endport, ipFamily); err != nil {
 					return err
 				}
 			}
@@ -269,7 +283,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 				comment := "rule to ACCEPT traffic from all sources to dest pods selected by policy name: " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, "", namedPortIPSetName,
-					endPoints.protocol, endPoints.port, endPoints.endport, ipFamily, policy); err != nil {
+					endPoints.protocol, endPoints.port, endPoints.endport, ipFamily); err != nil {
 					return err
 				}
 			}
@@ -281,7 +295,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 			comment := "rule to ACCEPT traffic from all sources to dest pods selected by policy name: " +
 				policy.name + " namespace " + policy.namespace
 			if err := npc.appendRuleToPolicyChain(policyChainName, comment, "", targetDestPodIPSetName,
-				"", "", "", ipFamily, policy); err != nil {
+				"", "", "", ipFamily); err != nil {
 				return err
 			}
 		}
@@ -297,7 +311,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 						policy.name + " namespace " + policy.namespace
 					if err := npc.appendRuleToPolicyChain(policyChainName, comment, srcIPBlockIPSetName,
 						targetDestPodIPSetName, portProtocol.protocol, portProtocol.port,
-						portProtocol.endport, ipFamily, policy); err != nil {
+						portProtocol.endport, ipFamily); err != nil {
 						return err
 					}
 				}
@@ -314,7 +328,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 					comment := "rule to ACCEPT traffic from specified ipBlocks to dest pods selected by policy name: " +
 						policy.name + " namespace " + policy.namespace
 					if err := npc.appendRuleToPolicyChain(policyChainName, comment, srcIPBlockIPSetName, namedPortIPSetName,
-						endPoints.protocol, endPoints.port, endPoints.endport, ipFamily, policy); err != nil {
+						endPoints.protocol, endPoints.port, endPoints.endport, ipFamily); err != nil {
 						return err
 					}
 				}
@@ -323,7 +337,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 				comment := "rule to ACCEPT traffic from specified ipBlocks to dest pods selected by policy name: " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, srcIPBlockIPSetName,
-					targetDestPodIPSetName, "", "", "", ipFamily, policy); err != nil {
+					targetDestPodIPSetName, "", "", "", ipFamily); err != nil {
 					return err
 				}
 			}
@@ -380,7 +394,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 					comment := "rule to ACCEPT traffic from source pods to dest pods selected by policy name " +
 						policy.name + " namespace " + policy.namespace
 					if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
-						namedPortIPSetName, endPoints.protocol, endPoints.port, endPoints.endport, ipFamily, policy); err != nil {
+						namedPortIPSetName, endPoints.protocol, endPoints.port, endPoints.endport, ipFamily); err != nil {
 						return err
 					}
 				}
@@ -393,7 +407,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 				comment := "rule to ACCEPT traffic from source pods to dest pods selected by policy name " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
-					dstPodIPSetName, "", "", "", ipFamily, policy); err != nil {
+					dstPodIPSetName, "", "", "", ipFamily); err != nil {
 					return err
 				}
 			}
@@ -406,7 +420,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 				comment := "rule to ACCEPT traffic from source pods to all destinations selected by policy name: " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
-					"", portProtocol.protocol, portProtocol.port, portProtocol.endport, ipFamily, policy); err != nil {
+					"", portProtocol.protocol, portProtocol.port, portProtocol.endport, ipFamily); err != nil {
 					return err
 				}
 			}
@@ -414,7 +428,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 				comment := "rule to ACCEPT traffic from source pods to all destinations selected by policy name: " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
-					"", portProtocol.protocol, portProtocol.port, portProtocol.endport, ipFamily, policy); err != nil {
+					"", portProtocol.protocol, portProtocol.port, portProtocol.endport, ipFamily); err != nil {
 					return err
 				}
 			}
@@ -426,7 +440,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 			comment := "rule to ACCEPT traffic from source pods to all destinations selected by policy name: " +
 				policy.name + " namespace " + policy.namespace
 			if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
-				"", "", "", "", ipFamily, policy); err != nil {
+				"", "", "", "", ipFamily); err != nil {
 				return err
 			}
 		}
@@ -441,7 +455,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 						policy.name + " namespace " + policy.namespace
 					if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
 						dstIPBlockIPSetName, portProtocol.protocol, portProtocol.port,
-						portProtocol.endport, ipFamily, policy); err != nil {
+						portProtocol.endport, ipFamily); err != nil {
 						return err
 					}
 				}
@@ -450,17 +464,18 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 				comment := "rule to ACCEPT traffic from source pods to specified ipBlocks selected by policy name: " +
 					policy.name + " namespace " + policy.namespace
 				if err := npc.appendRuleToPolicyChain(policyChainName, comment, targetSourcePodIPSetName,
-					dstIPBlockIPSetName, "", "", "", ipFamily, policy); err != nil {
+					dstIPBlockIPSetName, "", "", "", ipFamily); err != nil {
 					return err
 				}
 			}
 		}
 	}
+
 	return nil
 }
 
 func (npc *NetworkPolicyController) appendRuleToPolicyChain(policyChainName, comment, srcIPSetName, dstIPSetName,
-	protocol, dPort, endDport string, ipFamily api.IPFamily, policy networkPolicyInfo) error {
+	protocol, dPort, endDport string, ipFamily api.IPFamily) error {
 
 	args := make([]string, 0)
 	args = append(args, "-A", policyChainName)
@@ -492,21 +507,6 @@ func (npc *NetworkPolicyController) appendRuleToPolicyChain(policyChainName, com
 
 	args = append(args, "-m", "mark", "--mark", "0x10000/0x10000", "-j", "RETURN", "\n")
 	npc.filterTableRules[ipFamily].WriteString(strings.Join(args, " "))
-
-	// Extra logs to get more information about the policy dropping the packet via ulog2
-	logRuleComment := "\"rule to log dropped traffic\""
-
-	// The network policy annotation can include a log config
-	limit, limitBurst := getIptablesNFlogLimit(policy.annotations)
-
-	// LogComment is capped at 64 characters and we are using 16, hence policyNamespace and policyName
-	// must fit in 48 characters otherwise we can only log the first 24 characters
-	policyNamespaceAndName := safeJoin(policy.namespace, policy.name)
-	logComment := "\"DROP by policy " + policyNamespaceAndName + "\""
-	logArgs := []string{"-A", policyChainName, "-m", "comment", "--comment", logRuleComment, "-m", "limit",
-		"--limit", limit, "--limit-burst", limitBurst, "-m", "mark", "!", "--mark", "0x10000/0x10000",
-		"-j", "NFLOG", "--nflog-group", "100", "--nflog-prefix", logComment, "\n"}
-	npc.filterTableRules[ipFamily].WriteString(strings.Join(logArgs, " "))
 
 	return nil
 }

--- a/pkg/controllers/netpol/utils.go
+++ b/pkg/controllers/netpol/utils.go
@@ -124,7 +124,7 @@ func (npc *NetworkPolicyController) createPodWithPortPolicyRule(ports []protocol
 		comment := "rule to ACCEPT traffic from source pods to dest pods selected by policy name " +
 			policy.name + " namespace " + policy.namespace
 		if err := npc.appendRuleToPolicyChain(policyName, comment, srcSetName, dstSetName, portProtocol.protocol,
-			portProtocol.port, portProtocol.endport, ipFamily, policy); err != nil {
+			portProtocol.port, portProtocol.endport, ipFamily); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Moved the NFLOG rules on the policy creation loop to avoid to have logs in case of non dropped packet https://github.com/k3s-io/k3s/issues/9032